### PR TITLE
Fix contributors.sh, add commit counts

### DIFF
--- a/contributors.sh
+++ b/contributors.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # This script prints the list of contributors to the repository.
 # Usage: ./contributors.sh
-git log --pretty=format:"%an" | sort -u
+git log --pretty=format:"%an" | sort | uniq -c | sort -rn


### PR DESCRIPTION
PR #76 broke `contributors.sh`. This PR fixes it. It also adds a nice little commit count for each git author.